### PR TITLE
removed yaml unmarshal for auth_key

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/joho/godotenv"
 	"github.com/kelseyhightower/envconfig"
 	"github.com/sirupsen/logrus"
-	//	yaml "gopkg.in/yaml.v2"
-	"os"
-	"strings"
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -2,13 +2,12 @@ package main
 
 import (
 	"fmt"
-	"os"
-	"strings"
-
 	"github.com/joho/godotenv"
 	"github.com/kelseyhightower/envconfig"
 	"github.com/sirupsen/logrus"
-	yaml "gopkg.in/yaml.v2"
+	//	yaml "gopkg.in/yaml.v2"
+	"os"
+	"strings"
 )
 
 func main() {
@@ -34,11 +33,6 @@ func main() {
 }
 
 func preparePlugin(p *Plugin) error {
-	// the problem is, that p.AuthKey so far is "yaml" escaped string.
-	// To fix this issue, needs to yaml.Unmarshal this string simple string.
-	if err := yaml.Unmarshal([]byte(p.AuthKey), &p.AuthKey); err != nil {
-		return err
-	}
 	if p.Package == "" {
 		s := strings.Split(p.ChartPath, "/")
 		p.Package = s[len(s)-1]


### PR DESCRIPTION
Due to drone's new secret handling, yaml.Unmarshal is not needed anymore.

For more information about those changes, take a look at:

http://docs.drone.io/release-0.6.0-secrets