### PR TITLE
helm 3.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN go build -o /helm-builder
 FROM alpine:3
 
 ARG GCLOUD_VERSION=272.0.0
-ARG HELM_VERSION=v3.0.0
+ARG HELM_VERSION=v3.0.1
 
 RUN apk --update --no-cache add python tar openssl wget ca-certificates
 RUN mkdir -p /opt


### PR DESCRIPTION
Upgrade helm `3.0.0` to `3.0.1`. This patch version does not include any breaking changes and should be save to upgrade, see: https://github.com/helm/helm/releases/tag/v3.0.1